### PR TITLE
feat: add mute toggle for instrument

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 
 import Instrument from "../components/instrument";
-import Navbar from "../components/navbar"
+import Navbar from "../components/navbar";
+import MuteButton from "../components/mute-button";
 
 declare global {
   interface Window {
@@ -54,6 +55,7 @@ export default function Home() {
 
   const [scope, animate] = useAnimate(); // useAnimate hook for controlling animations
   const [hasScrolled, setHasScrolled] = useState(false); // Tracks if the user has scrolled
+  const [isMuted, setIsMuted] = useState(true);
 
   // Trigger initial animation on page load
   useEffect(() => {
@@ -123,7 +125,9 @@ export default function Home() {
     <main className="flex h-screen items-center justify-center bg-background dark:bg-black overflow-hidden">
       {/* Canvas for the grid background */}
 
-      <Instrument currentMode={currentMode} pitchModes={pitchModes}  />
+      <Instrument currentMode={currentMode} pitchModes={pitchModes} isMuted={isMuted} />
+
+      <MuteButton isMuted={isMuted} onToggle={() => setIsMuted((m) => !m)} />
 
       {/* Navbar - Only render if scrolled */}
       <Navbar visible={hasScrolled} />

--- a/src/components/instrument.tsx
+++ b/src/components/instrument.tsx
@@ -13,9 +13,10 @@ type PitchMode = "pentatonic" | "just_c" | "blues";
 interface MusicalGridProps {
   currentMode: PitchMode; // Pass the currentMode as a prop
   pitchModes: Record<PitchMode, { baseFrequency: number; frequencyStep?: number; scale?: number[] }>;
+  isMuted: boolean;
 }
 
-export default function Instrument({ currentMode, pitchModes }: MusicalGridProps) {
+export default function Instrument({ currentMode, pitchModes, isMuted }: MusicalGridProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   useEffect(() => {
@@ -37,6 +38,8 @@ export default function Instrument({ currentMode, pitchModes }: MusicalGridProps
 
     // Sound logic
     function playSound(frequency: number) {
+      if (isMuted) return;
+
       const oscillator = audioContext.createOscillator();
       const gainNode = audioContext.createGain();
       oscillator.connect(gainNode);
@@ -149,7 +152,7 @@ export default function Instrument({ currentMode, pitchModes }: MusicalGridProps
         window.removeEventListener("click", handleClick);
         window.removeEventListener("resize", handleResize);
     };
-  }, [currentMode, pitchModes]);
+  }, [currentMode, pitchModes, isMuted]);
 
   return <canvas ref={canvasRef} className="absolute inset-0 z-10" />;
 }

--- a/src/components/mute-button.tsx
+++ b/src/components/mute-button.tsx
@@ -1,0 +1,17 @@
+interface MuteButtonProps {
+  isMuted: boolean;
+  onToggle: () => void;
+}
+
+export default function MuteButton({ isMuted, onToggle }: MuteButtonProps) {
+  return (
+    <button
+      onClick={onToggle}
+      aria-label={isMuted ? "Unmute" : "Mute"}
+      className="fixed bottom-4 left-4 z-30 rounded-full bg-white/70 dark:bg-gray-800/70 p-2 shadow text-black dark:text-white"
+    >
+      {isMuted ? "🔇" : "🔊"}
+    </button>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable mute button and default muted state
- prevent instrument from playing when muted

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689dfe9b8604832b901bc9f9d391a876