### PR TITLE
feat: enrich contact page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,44 +1,62 @@
 'use client'
 
+import { useState } from "react"
+import { motion } from "framer-motion"
 import Navbar from "../../components/navbar"
 
-export default function Blog() {
+export default function Contact() {
+  const [copied, setCopied] = useState(false)
+
+  const copyEmail = async () => {
+    await navigator.clipboard.writeText("jdsimons017@gmail.com")
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
     <main className="max-w-3xl mx-auto px-4 py-16">
-    <Navbar visible={true} />
-      <br></br>
-      <h1 className="text-2xl  font-monoreg font-semibold mb-8">Contact me &#x263A;</h1>
-      <div className="text-xl font-monoreg"> 
-        <p>
-          Email me at<br></br>
-
-          <a href="mailto:jdsimons017@gmail.com">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="260" height="30"
-            viewBox="0 0 260 24"
-            className="inline-block align-middle"
+      <Navbar visible={true} />
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="mt-8 text-xl font-monoreg space-y-6"
+      >
+        <h1 className="text-2xl font-monoreg font-semibold">Contact me &#x263A;</h1>
+        <div className="flex items-center gap-2">
+          <a
+            href="mailto:jdsimons017@gmail.com"
+            className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-green-600 hover:text-green-600 dark:decoration-gray-300 dark:hover:decoration-white transition-colors"
           >
-            <text
-              x="0" y="18"
-              fontFamily="InputMonoRegular, monospace"
-              fontSize="16"
-              fill="#171717"
+            jdsimons017@gmail.com
+          </a>
+          <button
+            onClick={copyEmail}
+            aria-label="Copy email"
+            className="text-gray-500 hover:text-green-600 transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="w-5 h-5"
             >
-              jdsimons017@gmail.com
-            </text>
-          </svg>
-        </a>
-          
-          <br></br><br></br>
+              <path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1Zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2Zm0 16H8V7h11v14Z"/>
+            </svg>
+          </button>
+          {copied && <span className="text-sm text-gray-500">Copied!</span>}
+        </div>
+        <p>
           or find me on&nbsp;
-          <a 
+          <a
             href="https://www.linkedin.com/in/jun-simons/"
-            className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-blue-600 hover:text-blue-600 dark:decoration-gray-300 dark:hover:decoration-white transition-all">
-              LinkedIn
+            className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-blue-600 hover:text-blue-600 dark:decoration-gray-300 dark:hover:decoration-white transition-all"
+          >
+            LinkedIn
           </a>
         </p>
-      </div>
+      </motion.section>
     </main>
   )
 }
+


### PR DESCRIPTION
## Summary
- add fade-in animation and copy-to-clipboard interaction on contact page
- keep minimal design while offering clickable email and LinkedIn link

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8beaad0dc832b843158aeb9ff0ab1