### PR TITLE
Add theremin sound slider to contact page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,44 +1,52 @@
 'use client'
 
-import Navbar from "../../components/navbar"
+import { useState } from "react";
+import Navbar from "../../components/navbar";
+import Theremin from "../../components/theremin";
+import MuteButton from "../../components/mute-button";
 
 export default function Blog() {
+  const [isMuted, setIsMuted] = useState(false);
+
   return (
     <main className="max-w-3xl mx-auto px-4 py-16">
-    <Navbar visible={true} />
+      <Navbar visible={true} />
       <br></br>
       <h1 className="text-2xl  font-monoreg font-semibold mb-8">Contact me &#x263A;</h1>
-      <div className="text-xl font-monoreg"> 
+      <div className="text-xl font-monoreg">
         <p>
           Email me at<br></br>
 
           <a href="mailto:jdsimons017@gmail.com">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="260" height="30"
-            viewBox="0 0 260 24"
-            className="inline-block align-middle"
-          >
-            <text
-              x="0" y="18"
-              fontFamily="InputMonoRegular, monospace"
-              fontSize="16"
-              fill="#171717"
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="260" height="30"
+              viewBox="0 0 260 24"
+              className="inline-block align-middle"
             >
-              jdsimons017@gmail.com
-            </text>
-          </svg>
-        </a>
-          
+              <text
+                x="0" y="18"
+                fontFamily="InputMonoRegular, monospace"
+                fontSize="16"
+                fill="#171717"
+              >
+                jdsimons017@gmail.com
+              </text>
+            </svg>
+          </a>
+
           <br></br><br></br>
           or find me on&nbsp;
-          <a 
+          <a
             href="https://www.linkedin.com/in/jun-simons/"
-            className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-blue-600 hover:text-blue-600 dark:decoration-gray-300 dark:hover:decoration-white transition-all">
-              LinkedIn
+            className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-blue-600 hover:text-blue-600 dark:decoration-gray-300 dark:hover:decoration-white transition-all"
+          >
+            LinkedIn
           </a>
         </p>
       </div>
+      <Theremin isMuted={isMuted} />
+      <MuteButton isMuted={isMuted} onToggle={() => setIsMuted(!isMuted)} />
     </main>
-  )
+  );
 }

--- a/src/components/theremin.tsx
+++ b/src/components/theremin.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useRef, useEffect } from "react";
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
+interface ThereminProps {
+  isMuted: boolean;
+}
+
+export default function Theremin({ isMuted }: ThereminProps) {
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const oscRef = useRef<OscillatorNode | null>(null);
+  const gainRef = useRef<GainNode | null>(null);
+  const isPressedRef = useRef(false);
+
+  const getFrequency = (y: number, rect: DOMRect) => {
+    const min = 100;
+    const max = 1000;
+    const relative = 1 - (y - rect.top) / rect.height;
+    return min + relative * (max - min);
+  };
+
+  const start = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (isMuted) return;
+    isPressedRef.current = true;
+    if (!audioCtxRef.current) {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      audioCtxRef.current = new Ctx();
+    }
+    const ctx = audioCtxRef.current!;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    gain.gain.value = 0.1;
+    osc.frequency.value = getFrequency(e.clientY, e.currentTarget.getBoundingClientRect());
+    osc.start();
+    oscRef.current = osc;
+    gainRef.current = gain;
+  };
+
+  const move = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isPressedRef.current || !oscRef.current || !audioCtxRef.current) return;
+    const freq = getFrequency(e.clientY, e.currentTarget.getBoundingClientRect());
+    oscRef.current.frequency.setValueAtTime(freq, audioCtxRef.current.currentTime);
+  };
+
+  const stop = () => {
+    isPressedRef.current = false;
+    if (oscRef.current) {
+      oscRef.current.stop();
+      oscRef.current.disconnect();
+      oscRef.current = null;
+    }
+    if (gainRef.current) {
+      gainRef.current.disconnect();
+      gainRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    if (isMuted) {
+      stop();
+    }
+  }, [isMuted]);
+
+  return (
+    <div
+      className="w-full h-48 my-8 border border-gray-300 rounded"
+      onMouseDown={start}
+      onMouseMove={move}
+      onMouseUp={stop}
+      onMouseLeave={stop}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a Theremin component that maps cursor height to oscillator frequency
- wire up mute button and theremin on contact page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e986b0c832b8225b9ac9d2b84b7