### PR TITLE
Add theremin sound slider to contact page

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,44 +1,108 @@
 'use client'
 
-import Navbar from "../../components/navbar"
+import { useState } from "react";
+import { motion } from "framer-motion";
+import Navbar from "../../components/navbar";
+import Theremin from "../../components/theremin";
+import MuteButton from "../../components/mute-button";
+import { copyToClipboard } from "../../lib/copy-to-clipboard";
 
-export default function Blog() {
+export default function Contact() {
+  const [isMuted, setIsMuted] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const email = "jdsimons017@gmail.com";
+
+  const handleCopy = async () => {
+    const ok = await copyToClipboard(email);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
   return (
     <main className="max-w-3xl mx-auto px-4 py-16">
-    <Navbar visible={true} />
-      <br></br>
-      <h1 className="text-2xl  font-monoreg font-semibold mb-8">Contact me &#x263A;</h1>
-      <div className="text-xl font-monoreg"> 
-        <p>
-          Email me at<br></br>
-
-          <a href="mailto:jdsimons017@gmail.com">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="260" height="30"
-            viewBox="0 0 260 24"
-            className="inline-block align-middle"
-          >
-            <text
-              x="0" y="18"
-              fontFamily="InputMonoRegular, monospace"
-              fontSize="16"
-              fill="#171717"
+      <Navbar visible={true} />
+      <motion.section
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.5 }}
+        className="mt-8"
+      >
+        <h1 className="text-2xl font-monoreg font-semibold mb-8">
+          Contact me &#x263A;
+        </h1>
+        <div className="text-xl font-monoreg">
+          <p className="mb-6">
+            Email me at
+            <br />
+            <span className="flex items-center gap-2 mt-2">
+              <a href={`mailto:${email}`} className="group">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="260"
+                  height="30"
+                  viewBox="0 0 260 24"
+                  className="inline-block align-middle"
+                >
+                  <text
+                    x="0"
+                    y="18"
+                    fontFamily="InputMonoRegular, monospace"
+                    fontSize="16"
+                    className="fill-neutral-900 dark:fill-neutral-100 transition-colors group-hover:fill-blue-600"
+                  >
+                    {email}
+                  </text>
+                </svg>
+              </a>
+              <button
+                onClick={handleCopy}
+                aria-label="Copy email"
+                className="p-1 text-sm text-gray-600 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-400 transition-colors"
+              >
+                {copied ? (
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="w-5 h-5"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                ) : (
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="w-5 h-5"
+                  >
+                    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                )}
+              </button>
+            </span>
+          </p>
+          <p>
+            or find me on&nbsp;
+            <a
+              href="https://www.linkedin.com/in/jun-simons/"
+              className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-blue-600 hover:text-blue-600 dark:decoration-gray-300 dark:hover:decoration-white transition-all"
             >
-              jdsimons017@gmail.com
-            </text>
-          </svg>
-        </a>
-          
-          <br></br><br></br>
-          or find me on&nbsp;
-          <a 
-            href="https://www.linkedin.com/in/jun-simons/"
-            className="underline decoration-gray-500 decoration-2 underline-offset-4 hover:decoration-blue-600 hover:text-blue-600 dark:decoration-gray-300 dark:hover:decoration-white transition-all">
               LinkedIn
-          </a>
-        </p>
-      </div>
+            </a>
+          </p>
+        </div>
+        <Theremin isMuted={isMuted} />
+        <MuteButton isMuted={isMuted} onToggle={() => setIsMuted(!isMuted)} />
+      </motion.section>
     </main>
-  )
+  );
 }

--- a/src/components/theremin.tsx
+++ b/src/components/theremin.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useRef, useEffect } from "react";
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
+interface ThereminProps {
+  isMuted: boolean;
+}
+
+export default function Theremin({ isMuted }: ThereminProps) {
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const oscRef = useRef<OscillatorNode | null>(null);
+  const gainRef = useRef<GainNode | null>(null);
+  const isPressedRef = useRef(false);
+
+  const getFrequency = (y: number, rect: DOMRect) => {
+    const min = 100;
+    const max = 1000;
+    const relative = 1 - (y - rect.top) / rect.height;
+    return min + relative * (max - min);
+  };
+
+  const start = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (isMuted) return;
+    isPressedRef.current = true;
+    if (!audioCtxRef.current) {
+      const Ctx = window.AudioContext || window.webkitAudioContext;
+      audioCtxRef.current = new Ctx();
+    }
+    const ctx = audioCtxRef.current!;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    gain.gain.value = 0.1;
+    osc.frequency.value = getFrequency(e.clientY, e.currentTarget.getBoundingClientRect());
+    osc.start();
+    oscRef.current = osc;
+    gainRef.current = gain;
+  };
+
+  const move = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isPressedRef.current || !oscRef.current || !audioCtxRef.current) return;
+    const freq = getFrequency(e.clientY, e.currentTarget.getBoundingClientRect());
+    oscRef.current.frequency.setValueAtTime(freq, audioCtxRef.current.currentTime);
+  };
+
+  const stop = () => {
+    isPressedRef.current = false;
+    if (oscRef.current) {
+      oscRef.current.stop();
+      oscRef.current.disconnect();
+      oscRef.current = null;
+    }
+    if (gainRef.current) {
+      gainRef.current.disconnect();
+      gainRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    if (isMuted) {
+      stop();
+    }
+  }, [isMuted]);
+
+  return (
+    <div
+      className="w-full h-48 my-8 border border-gray-300 rounded"
+      onMouseDown={start}
+      onMouseMove={move}
+      onMouseUp={stop}
+      onMouseLeave={stop}
+    />
+  );
+}
+

--- a/src/lib/copy-to-clipboard.ts
+++ b/src/lib/copy-to-clipboard.ts
@@ -1,0 +1,10 @@
+'use client'
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- add a Theremin component that maps cursor height to oscillator frequency
- wire up mute button and theremin on contact page
- wrap contact info in fade-in section and provide copy-to-clipboard email link

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e986b0c832b8225b9ac9d2b84b7